### PR TITLE
Lower the weight of P/A features, misc. updates

### DIFF
--- a/inventory.ini
+++ b/inventory.ini
@@ -1,4 +1,5 @@
 [targets]
-geoname-lookup.eha.io ansible_user=ubuntu
+geoname-lookup.eha.io ansible_user=ubuntu elasticsearch_load_from_backup=true
+#54.197.204.16 ansible_user=ubuntu apache_vhosts_ssl_override=[] elasticsearch_clear_data=true export=true
 # To deploy locally uncommend the line below and remove the line above.
 #localhost ansible_connection=local

--- a/roles/elasticsearch-load/defaults/main.yml
+++ b/roles/elasticsearch-load/defaults/main.yml
@@ -1,1 +1,3 @@
 docker_importer_path: /tmp/docker_importer
+elasticsearch_load_from_backup: false
+elasticsearch_clear_data: false

--- a/roles/elasticsearch-load/files/importer/Dockerfile
+++ b/roles/elasticsearch-load/files/importer/Dockerfile
@@ -1,3 +1,4 @@
+# In newer versions of node the geonames-importer package causes a stack overflow.
 FROM node:0
 ADD . .
 RUN npm install

--- a/roles/elasticsearch-load/files/importer/main.js
+++ b/roles/elasticsearch-load/files/importer/main.js
@@ -1,9 +1,9 @@
 var addAdminRegionNames = require('./addAdminRegionNames');
 var Importer = require('geonames-importer');
-var Downloader = require('geonames-importer/downloader');
 console.assert(process.env.ELASTICSEARCH_HOST);
 var importer = new Importer({
   index: 'geonames',
+  filename: '/allCountries.txt',
   elasticsearch: {
     host: process.env.ELASTICSEARCH_HOST
   },
@@ -25,15 +25,18 @@ var importer = new Importer({
       } else {
         item.alternateNames = [];
       }
+      var rawNames = {};
+      rawNames[item.name] = 1;
+      item.alternateNames.forEach(function(name){
+        rawNames[name] = 1;
+      });
+      item.rawNames = Object.keys(rawNames);
       return item;
     }
   ]
 });
-var downloader = new Downloader({
-  tmp: '/tmp'
-});
 importer
-.import(downloader.country())
+.import()
 .then(function () {
   console.log('finished loading geonames');
   addAdminRegionNames();

--- a/roles/elasticsearch-load/files/importer/package.json
+++ b/roles/elasticsearch-load/files/importer/package.json
@@ -4,13 +4,7 @@
   },
   "dependencies": {
     "geonames-importer": "^0.0.6",
-    "elasticsearch": "^2.4.3",
-    "elasticsearch-streams": "0.0.6"
-  },
-  "devDependencies": {
-    "expect.js": "^0.3.1",
-    "jshint": "^2.5.6",
-    "mocha": "^2.0.1",
-    "should": "^4.1.0"
+    "elasticsearch": "^13.0.1",
+    "elasticsearch-streams": "0.0.9"
   }
 }

--- a/roles/elasticsearch-load/tasks/main.yml
+++ b/roles/elasticsearch-load/tasks/main.yml
@@ -3,8 +3,20 @@
   docker_image:
     name: "elasticsearch:2.4.1"
 
+- name: "Remove old elasticsearch data directory"
+  file: path="{{elasticsearch_data_path}}" state=absent
+  when: "elasticsearch_clear_data"
+
 - name: "Ensure elasticsearch data directory exists at: {{elasticsearch_data_path}}"
   file: path="{{elasticsearch_data_path}}" state=directory
+
+- name: "Download elasticsearch backup"
+  command: "aws s3 cp s3://bsve-integration/elasticsearch-data.tar.gz /tmp/elasticsearch-data.tar.gz"
+  when: "elasticsearch_load_from_backup"
+
+- name: "Restore elasticsearch backup"
+  shell: "tar -xvzf /tmp/elasticsearch-data.tar.gz -C {{elasticsearch_data_path}}"
+  when: "elasticsearch_load_from_backup"
 
 - name: Start elasticsearch container
   docker_container:
@@ -16,23 +28,13 @@
       - "9200:9200"
     volumes:
       - "{{elasticsearch_data_path}}:/usr/share/elasticsearch/data"
-      #- "{{elasticsearch_config_path}}:/usr/share/elasticsearch/config"
-
-- name: Copy importer source code
-  synchronize: src="importer/" dest="{{docker_importer_path}}"
-
-- name: Build importer image
-  docker_image:
-    path: "{{docker_importer_path}}"
-    name: importer
-    force: true
 
 - name: Wait for elasticsearch
   uri:
     url: http://localhost:9200/
   register: elasticsearch_ping
   until: "elasticsearch_ping.get('json')"
-  retries: 5
+  retries: 6
   delay: 10
 
 - name: Ensure geonames index exists
@@ -40,11 +42,59 @@
   uri:
     url: http://localhost:9200/geonames
     method: PUT
+    body:
+      settings:
+        index:
+          analysis:
+            analyzer:
+              analyzer_keyword:
+                tokenizer: "keyword"
+                filter: "lowercase"
+      mappings:
+        geoname:
+          properties:
+            rawNames:
+              type: "string"
+              analyzer: "analyzer_keyword"
+              # Make it so having many names does not dimish the score given
+              # to a matching raw name.
+              norms: 
+                enabled: false
+    body_format: "json"
 
 - name: Count items in geonames index
   uri:
     url: http://localhost:9200/geonames/_count
   register: geonames_count
+
+- name: Copy importer source code
+  synchronize: src="importer/" dest="{{docker_importer_path}}"
+  when: "geonames_count is undefined or geonames_count.json.count == 0"
+  tags: rerun-importer
+
+- name: Download geonames data
+  get_url:
+    url: http://download.geonames.org/export/dump/allCountries.zip
+    dest: "{{ docker_importer_path }}/allCountries.zip"
+  when: "geonames_count is undefined or geonames_count.json.count == 0"
+  tags: rerun-importer
+
+- name: Extract geonames zip
+  unarchive:
+    src: "{{ docker_importer_path }}/allCountries.zip"
+    dest: "{{ docker_importer_path }}"
+    copy: no
+    creates: "{{ docker_importer_path }}/allCountries.txt"
+  when: "geonames_count is undefined or geonames_count.json.count == 0"
+  tags: rerun-importer
+
+- name: Build importer image
+  docker_image:
+    path: "{{docker_importer_path}}"
+    name: importer
+    force: true
+  when: "geonames_count is undefined or geonames_count.json.count == 0"
+  tags: rerun-importer
 
 - name: Start importer
   docker_container:
@@ -55,7 +105,6 @@
     restart: true
     env:
       ELASTICSEARCH_HOST: "{{ansible_default_ipv4.address}}:9200"
-  when: "geonames_count.json.count == 0"
+  when: "geonames_count is undefined or geonames_count.json.count == 0"
   register: import_result
-
-#- debug: var=import_result
+  tags: rerun-importer

--- a/roles/export-containers/tasks/main.yml
+++ b/roles/export-containers/tasks/main.yml
@@ -1,8 +1,10 @@
 ---
 - name: Tar and zip elasticsearch data
   shell: "tar -zcvf /tmp/elasticsearch-data.tar.gz {{elasticsearch_data_path}}"
+
 - command: "aws s3 cp /tmp/elasticsearch-data.tar.gz s3://bsve-integration/elasticsearch-data.tar.gz"
 
 - name: Tar and zip geonames-api container
   shell: "docker save geonames-api | gzip > /tmp/geonames-api.tar.gz"
+
 - command: "aws s3 cp /tmp/geonames-api.tar.gz s3://bsve-integration/geonames-api.tar.gz"

--- a/roles/init/tasks/main.yml
+++ b/roles/init/tasks/main.yml
@@ -6,6 +6,7 @@
     - python-pip
     - python-dev
     - curl
+    - zip
 - name: Install global python modules
   pip: name={{item}}
   with_items:

--- a/roles/lookup-api/defaults/main.yml
+++ b/roles/lookup-api/defaults/main.yml
@@ -4,7 +4,7 @@ api_url: "https://{{domain_name}}/api"
 
 apidoc_conf:
   name: "EHA Geoname Lookup API"
-  version: "0.0.1"
+  version: "0.0.2"
   description: >
     This is an API for looking up geonames from geonames.org based on a free-text search.
     Geonames.org data is licenced under the CC Attribution 3.0 license https://creativecommons.org/licenses/by/3.0/
@@ -19,9 +19,13 @@ test_lookups:
     id: "5815135"
   - name: "United States"
     id: "6252001"
-  - name: "Riverside, OR"
-    id: "7176033"
-  - name: "Riverside, Vermont"
+  - name: "springfield, IL"
+    id: "4250542"
+  - name: "Riverside, Chittenden County, Vermont"
     id: "5240320"
   - name: "Ghana"
     id: "2300660"
+  - name: "Lake Superior, Ontario"
+    id: "6048728"
+  - name: "China"
+    id: "1814991"

--- a/roles/lookup-api/files/geonames-api/package.json
+++ b/roles/lookup-api/files/geonames-api/package.json
@@ -12,11 +12,5 @@
     "coffee-script": ">= 0.0.0",
     "express": ">= 3.0.0",
     "body-parser": ">= 0.0.0"
-  },
-  "devDependencies": {
-    "expect.js": "^0.3.1",
-    "jshint": "^2.5.6",
-    "mocha": "^2.0.1",
-    "should": "^4.1.0"
   }
 }

--- a/roles/lookup-api/tasks/main.yml
+++ b/roles/lookup-api/tasks/main.yml
@@ -27,9 +27,10 @@
     url: "http://{{ansible_host}}/api/lookup?q=test"
   register: result
   until: "result.status == 200"
-  retries: 5
+  retries: 6
   delay: 10
   tags: api-tests
+
 - name: Run API tests
   uri: 
     url: "http://{{ansible_host}}/api/lookup"
@@ -39,8 +40,10 @@
   with_items: "{{test_lookups}}"
   tags: api-tests
   register: test_results
+
 # - debug: var=test_results
 #   tags: api-tests
+
 - name: Check test results
   assert: that="test_results.results[item.0].json.hits.0._source.id == item.1.id"
   with_indexed_items: "{{test_lookups}}"

--- a/site.yml
+++ b/site.yml
@@ -4,7 +4,6 @@
   become_user: root
   vars:
     elasticsearch_data_path: "/mnt/elasticsearch/data"
-    export: false
     domain_name: "geoname-lookup.eha.io"
     webroot: "/var/www"
     ssl_directory: "/etc/letsencrypt/live/{{domain_name}}"
@@ -18,6 +17,13 @@
       ProxyPreserveHost On
       ProxyPassMatch ^/(?!\.well-known)(.*) http://localhost:{{ main_server_port }}/$1
       ProxyPassReverse ^/(?!\.well-known)(.*) http://localhost:{{ main_server_port }}/$1
+    apache_vhosts_ssl_default:
+      - servername: "{{domain_name}}"
+        documentroot: "{{webroot}}"
+        certificate_file: "{{certpath}}"
+        certificate_key_file: "{{keypath}}"
+        certificate_chain_file: "{{chainpath}}"
+        extra_parameters: "{{apache_extra_parameters}}"
   roles:
     - name: init
       tags: init
@@ -26,8 +32,10 @@
       swapfile_location: "/swapfile"
       tags: swap
     - name: angstwad.docker_ubuntu
-      # There is a version comparison bug on versions >= 1.10.0
-      pip_version_docker_py: "1.9.0"
+      # Due to this bug the version need to be pinned.
+      # https://github.com/ansible/ansible/issues/20492
+      pip_version_docker_compose: '1.9.0'
+      pip_version_docker_py: '1.10.6'
       tags: docker
     - name: elasticsearch-load
       tags: elasticsearch-load
@@ -48,13 +56,8 @@
         - alias.load
         - proxy_wstunnel.load
       apache_mods_disabled: []
-      apache_vhosts_ssl:
-        - servername: "{{domain_name}}"
-          documentroot: "{{webroot}}"
-          certificate_file: "{{certpath}}"
-          certificate_key_file: "{{keypath}}"
-          certificate_chain_file: "{{chainpath}}"
-          extra_parameters: "{{apache_extra_parameters}}"
+      apache_remove_default_vhost: true
+      apache_vhosts_ssl: "{{ apache_vhosts_ssl_override | default(apache_vhosts_ssl_default) }}"
       apache_vhosts:
         - servername: "{{domain_name}}"
           documentroot: "{{webroot}}"
@@ -62,7 +65,7 @@
       tags: apache
     - name: export-containers
       tags: export
-      when: export
+      when: "{{ export | default(true) }}"
   post_tasks:
     - name: Import log tail
       command: docker logs --tail 50 importer-c


### PR DESCRIPTION
This lowers the weight given to geonames that are cities/states/countries so that other types of features like lakes can be found. In part this was done by creating a rawNames field where exact name matches can boost a geonames score. This also makes a number of updates to the import script to use a newer version of elastic search. The Ansible script was updated to make it easier to build an updated database on one instance then download it on the production instance so as to eliminate the downtime caused by running the import script.